### PR TITLE
Adds country option to performCheck function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ If so, pass an array as second argument.
 | localVersion      | version currently running on the device |
 | title, message..  | same options as specified in the [Options](#options) section | 
 
+## performCheck options
+Optional, in some cases it may be necessary to perform a specific check.
+The app may only be available in some countries, so you need to make explicit the contry code. 
+
+| value    | Description                                                                                                   | default                                     |
+|----------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+| bundleId | id that identifies the app (ex: com.apple.mobilesafari)                                                       | DeviceInfo.getBundleId()                    |
+| country  | [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) | undefined (the API won't filter by country) |
+
 
 #### TADAAAA!
 ![update](http://i.imgur.com/PKreDAS.png)

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,11 @@ type VersionSpecificOptions = {
   localVersion: string;
 } & PromptUserOptions;
 
+type PerformCheckOption = {
+  bundleId: string;
+  country?: string;
+}
+
 type PerformCheck = {
   updateIsAvailable: boolean;
   latestInfo: ITunesResponse;
@@ -63,7 +68,7 @@ type PerformCheck = {
 
 declare const siren: {
   promptUser: (defaultOptions: PromptUserOptions = {}, versionSpecificOptions: VersionSpecificOptions[] = []) => void;
-  performCheck: () => Promise<PerformCheck>;
+  performCheck: (performCheckOptions?: PerformCheckOption) => Promise<PerformCheck>;
 }
 
 export default siren;

--- a/index.js
+++ b/index.js
@@ -15,16 +15,17 @@ const createAPI = (baseURL = 'https://itunes.apple.com/') => {
   })
 
   return {
-    getLatest: (bundleId) => api.get('lookup', {bundleId})
+    getLatest: (bundleId, country = undefined) => api.get('lookup', { bundleId, country })
   }
 }
 
-const performCheck = (bundleId = DeviceInfo.getBundleId()) => {
+const defaultCheckOptions = { bundleId: DeviceInfo.getBundleId(), country: undefined }
+const performCheck = ({ bundleId = defaultCheckOptions.bundleId, country } = defaultCheckOptions) => {
   let updateIsAvailable = false
   const api = createAPI()
 
   // Call API
-  return api.getLatest(bundleId).then(response => {
+  return api.getLatest(bundleId, country).then(response => {
     let latestInfo = null
     // Did we get our exact result?
     if (response.ok && response.data.resultCount === 1) {
@@ -75,8 +76,8 @@ const showUpgradePrompt = (appId, {
   )
 }
 
-const promptUser = (defaultOptions = {}, versionSpecificOptions = [], bundleId) => {
-  performCheck(bundleId).then(sirenResult => {
+const promptUser = (defaultOptions = {}, versionSpecificOptions = [], bundleId, country = undefined) => {
+  performCheck({ bundleId, country }).then(sirenResult => {
     if (sirenResult.updateIsAvailable) {
       const options =
           versionSpecificOptions.find(o => o.localVersion === DeviceInfo.getVersion())


### PR DESCRIPTION
This PR adds the ability to make a itunes lookup for specific country limited apps.
Now you can pass to performCheck function's optional param, a country code (in addition to the bundleId).


Summary:
- changes performCheck function signature from performCheck(bundleId: string) to performCheck(option?: PerformCheckOption) (more extensible for optional parameters)
- adds PerformCheckOption type
- update README.md

