### PR TITLE
Updates the react-native-device-info version to 8.7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,9 @@
       "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "react-native-device-info": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-0.9.3.tgz",
-      "integrity": "sha1-TGfWefVN9Sd6zokOGuqwNKYmWtg="
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.7.0.tgz",
+      "integrity": "sha512-Zr0JNHSEPy2RWObWwUp9npTEWSG5HyY+nR/mRkf6ZTU5zd8oskarnPcCxAgwYhJbvshHSZbZIDRxCVCskXSpEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "homepage": "https://github.com/GantMan/react-native-siren#readme",
   "dependencies": {
     "apisauce": "^2.1.1",
-    "react-native-device-info": "^0.9.3"
+    "react-native-device-info": "^8.7.0"
   }
 }


### PR DESCRIPTION
I noticed that this package is using a pretty old version of `react-native-device-info`. There isn't anything inherently wrong with it, but in some cases it can cause an issue whre multiple versions of `react-native-device-info` are installed. 

For example, I am using the device info package at version 8.7+ in my project, and after installing siren, in my lockfile, there are 2 versions installed.