### PR TITLE
fix: append timestamp to bypass iTunes Lookup API caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const createAPI = (baseURL = 'https://itunes.apple.com/') => {
   })
 
   return {
-    getLatest: (bundleId, country = undefined) => api.get('lookup', { bundleId, country })
+    getLatest: (bundleId, country = undefined) => api.get('lookup', { bundleId, country, ts: Date.now() })
   }
 }
 


### PR DESCRIPTION
There is a caching issue with the iTunes Lookup API.

It is unclear whether the problem is caused by client-side or server-side caching,

but the API functions correctly when we bypass the cache by appending a query parameter such as /lookup?ts=1747401120293